### PR TITLE
New remote branches when pushing

### DIFF
--- a/guide/git_flow/bibliography.md
+++ b/guide/git_flow/bibliography.md
@@ -69,21 +69,36 @@ Online courses and step-by-step demonstrations explaining the most popular Git c
     https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History
     
 .. [rewriting_git_history2]
-    Tutorial listing the rewriting option Git offers.
+    Tutorial listing the rewriting options Git offers.
     
     https://www.atlassian.com/git/tutorials/rewriting-history#git-rebase-i
+    
+.. [sync_remote]
+    Explains how to work with remote repositories. Description of `git push` and `git pull` commands. 
+    
+    https://www.atlassian.com/git/tutorials/syncing
+
+.. [push]
+   `Git push` documentation page.
+   
+   https://git-scm.com/docs/git-push
+
+.. [pull]
+   `Git pull` documentation page. 
+   
+   https://git-scm.com/docs/git-pull
 ```
 
 ### GitHub
 #### Pull Requests (PR)
 ```{eval-rst}
 .. [about_pull_requests] 
-   Explains the basics about Pull requests
+   Explains the basics about Pull requests.
 
    https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
 
 .. [creating_a_pull_requests] 
-   Tutorial about how to open a new pull request
+   Tutorial about how to open a new pull request.
 
    https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request
    
@@ -141,7 +156,7 @@ Online courses and step-by-step demonstrations explaining the most popular Git c
 #### Reference
 ```{eval-rst}
 .. [github_docs] 
-   GitHub.com official documentation
+   GitHub.com official documentation.
 
    https://docs.github.com/en/github
 ```
@@ -179,7 +194,7 @@ Online courses and step-by-step demonstrations explaining the most popular Git c
    https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase
    
 .. [rebase-vs-merge]
-   A clear overview over the two merging strategies
+   A clear overview over the two merging strategies.
    
    https://www.atlassian.com/git/tutorials/merging-vs-rebasing
 ```

--- a/guide/git_flow/git_basics.md
+++ b/guide/git_flow/git_basics.md
@@ -91,3 +91,71 @@ If you are interested in delving into the ideas explored in this section, explor
 * Enlightening {ref}`tutorial<merge-basic>` about merge command. It includes the multiple 
   options this command offers, and the different merge strategies. 
 :::
+
+
+
+## Joining histories
+
+Once you have finished your work, and the new modifications satisfy your criteria, you are in position to integrate all these changes into the main line of development and share your thoughts with your teammates. Git offers two basic utilities to incorporate code from one branch into another, `git merge` and `git rebase`. Despite sharing a common goal, the method and philosophy behind these two are very different.
+
+:::{admonition} Remember
+:class: important
+Git branches are merely pointers to specific commits in Git history. They are not new repositories or folders. 
+:::
+
+### Git Merge
+
+`git merge` combines content from different branches into a single, unified commit. The process is the following: `git merge` takes two branch pointers and identifies their common commit ancestor. Once git locates this point, it generates a unique "merge commit" (in the current branch) that combines all committed changes from their common parent. This new commit is unique in the sense that it depends on two parent commits. `git merge` only modifies the target branch; the source branch history remains unaltered. 
+
+### Git Rebase
+
+`git rebase` is the second method to integrate changes. Rebasing compresses the content of the source branch into a single patch and integrates it on top of the target branch. In this way, we transfer the finished work from one branch to another, rewriting and flattening the history. It appears as if the entire sequence of commits had been created from a different commit, achieving a linear project history. Internally, what Git is doing is replicating the commit sequence of the source branch onto the target base, creating new commits for each commit in the original branch. The primary motivation for using `git rebase` is to achieve a linear project history. 
+
+:::{figure-md} rebase
+:width: 400px
+:align: center
+
+![rebase](images/rebase.png)
+
+`git rebase` captures the content from one branch and reapplies it on top of another. In that way, rebasing changes the base of our branch to a different commit
+:::
+
+:::{admonition} Good practices
+:class: tip
+An excellent exercise to avoid merging conflicts when pushing your content, either to the main branch or to a remote repository, is rebasing your changes with the most recent version of main. In this way, you guarantee that your changes are based on the most updated version of the repository, facilitating the merging process.
+:::
+
+Consider the following scenario: you have worked for several days on an additional feature for a program. Meanwhile, the main line has been updated multiple times in the remote repository by your teammates, leaving your files obsolete. If you want to push your work to remote and open a Pull Request to merge your fresh additions to _main_, a good practice is rebasing your content with the most updated version of the remote repository.
+
+1. First, you have to download the remote main branch to include all these new modifications that have been added: 
+`git pull origin main`
+2. Once you have your local main branch updated, you have to move to your local working environment: 
+`git checkout feature`
+3. Sitting on your branch, rebase your modifications with _main_: 
+`git rebase main`
+
+_Eureka_! Now your branch is based on the remote main branch and it is ready to be pushed without any problem. 
+
+### Git Rebase -i 
+An interesting option `git rebase` offers is the interactive mode. The flag `-i` begins the interactive mode, which gives you the opportunity of rebasing the commits individually as well as modifying their properties during the process. In this way, you can determine how the sequence of commits is transferred to the new base. 
+Besides, this mode opens the door to rewriting your Git history, using `git rebase -i HEAD~` plus the number of commits you want to rewrite. With this command, instead of rebasing against a distinct branch, you are "shifting" your base to the same point, while allowing you to remodel the structure of your commits. `git rebase -i` is extensively used (and widely recommended) before pushing your modifications to remote; you can rectify your changes, reorganize your history, and keep the number of commits to a minimum.
+
+`git rebase` not only allows you to rewrite your history, but it reinforces the concept of branches as pointers: next to `git rebase` must be placed a reference, either the label that refers to an individual commit (to rewrite your history); or a target branch to integrate your changes linearly. 
+
+:::{admonition} Resources
+:class: seealso 
+You will be able to find more literature about merging utilities in the following links: 
+* {ref}`Tutorial<merge-basic>` about `git merge`. 
+* In-depth {ref}`tutorial<rebase-basic>` about `git rebase`, including the interactive mode. 
+* {ref}`Conceptual discussion<rebase-vs-merge>` about the two merging strategies.
+* Immerse in the most complete {ref}`source<pro_git_book>` about Git. 
+* We encourage to exercise `merge` and `rebase` tools by using the {ref}`interactive tutorials<git_lab_branching>`.  
+:::
+
+### Rewriting history
+Before pushing your modifications to your shared repository, having a clean, organized history is strongly recommended to help the reviewing process to your comrades (and, of course, to facilitate your understanding of the working flow). Git offers multiple work flow customization tools that give you total control over the project development. We mentioned `git rebase -i`, but there are more options to restructure your Git commits, such as `git commit --amend`. These {ref}`two<rewriting_git_history>` essential {ref}`references<rewriting_git_history2>` contain __everything__ you should know about history-rewriting commands. These sources expose the topic in such a precise and straightforward manner that we are unable to include something relevant to the discussion.
+
+
+
+
+

--- a/guide/git_flow/how_to.md
+++ b/guide/git_flow/how_to.md
@@ -23,6 +23,21 @@ and use the tokens instead of your password.
   
 ### Git
 
+#### _Git push_ and _Git pull_. Remote branches  
+
+Once you are done introducing your additions to the project and your files are ready to be uploaded, the easiest way to create a new remote branch to host your local work is using `git push [remote alias] [local branch name]`. This will create a remote branch (named after the source branch) that will store the last modifications of your _local branch_. Git allows you to choose the name of the remote branch, adding to `push` the tag `[source local branch]:[destination remote branch]` instead of `[local branch name]`. In this way, the sentence `git push origin _local feature_:_remote feature_` will push to the remote repository (referred by _origin_) the changes introduced in your local branch _local feature_ to the remote branch _remote feature_.
+In case that you are suffering some problems when pushing your commits, you can override the remote branch with the contents pushed from your local branch using `git push -f` instead of `git push`. The remote branch being the "true" Git history by default, what this command does is telling Git that the true source is the local branch, having preference over the remote one. One must be extremely careful when using this option, as it will erase the remote branch content.
+
+You can download a remote repository using `git pull`. Sitting on the branch where you want to store the remote content, you must introduce `git pull [remote alias] [remote branch name]` to download the last version of the introduced remote branch. 
+
+:::{admonition} Resources
+:class: seealso
+A complete description of `git pull`/`git push` and the options they offer can be found in the following links:
+* {ref}`Syncing tutorial<sync_remote>` and references therein. 
+* {ref}`Git push<push>` documentation page.
+* {ref}`Git pull<pull>` documentation page. 
+:::
+
 #### Interactive rebase
 Follow {ref}`this tutorial<interactive_rebase>`
 


### PR DESCRIPTION
Added new section to `how-to` file explaining how to create new remote branches when pushing local changes to remote. I consider this method the easiest way to create new remote branches containing the local modifications (this problem was discussed in our weekly meetings). 